### PR TITLE
feat: update OpenFeature provider to 0.2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: ruby/setup-ruby@319994f95fa847cf3fb3cd3dbe89f6dcde9f178f # v1.295.0
         with:
-          ruby-version: 3.1
+          ruby-version: 3.4
 
       - name: Install dependencies
         run: bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'launchdarkly-openfeature-server-sdk', '~> 0.1'
+gem 'launchdarkly-openfeature-server-sdk', '~> 0.2'
 gem 'launchdarkly-server-sdk'
 gem 'listen', '~> 3.3'
 gem 'openfeature-sdk'

--- a/main.rb
+++ b/main.rb
@@ -16,7 +16,7 @@ end
 provider = LaunchDarkly::OpenFeature::Provider.new(sdk_key)
 
 OpenFeature::SDK.configure do |config|
-  config.set_provider(provider)
+  config.set_provider_and_wait(provider)
 
   # Set up the context properties. This context should appear on your LaunchDarkly contexts dashboard
   # soon after you run the demo.


### PR DESCRIPTION
## Summary

Updates the `launchdarkly-openfeature-server-sdk` gem constraint from `~> 0.1` to `~> 0.2` in the hello app's Gemfile. Provider 0.2.0 updates its dependency on `openfeature-sdk` from `~> 0.4.0` to `~> 0.6.0`, bringing the example in line with the latest released versions of both the provider and the OpenFeature SDK.

`Gemfile.lock` is gitignored in this repo, so it is not part of this diff.

### Additional changes required by the SDK upgrade

- **`main.rb`**: Changed `config.set_provider(provider)` → `config.set_provider_and_wait(provider)`. In `openfeature-sdk` 0.6.x, `set_provider` now initializes the provider **asynchronously** in a new thread, whereas 0.4.x did it synchronously. Without this change, `fetch_boolean_value` is called before the LaunchDarkly client is ready, causing the app to exit with the default value.
- **`ci.yml`**: Updated CI workflow from Ruby 3.1 to Ruby 3.4. Provider 0.2.0 has a hard requirement of `ruby >= 3.4`, so `bundle install` fails on older Rubies.

## Review & Testing Checklist for Human

- [ ] **Verify `set_provider_and_wait` behavior**: Confirm the app correctly waits for the LaunchDarkly client to initialize before evaluating flags. Run `bundle install && LAUNCHDARKLY_SDK_KEY=<key> LAUNCHDARKLY_FLAG_KEY=sample-feature bundle exec ruby main.rb` with Ruby 3.4+ and check that the flag evaluates to a real value (not the default `false`).
- [ ] **Ruby 3.4 runtime change**: CI moved from Ruby 3.1 → 3.4. Confirm this is acceptable and that no other tooling or documentation assumes 3.1.
- [ ] **README Ruby version**: The README currently says nothing about minimum Ruby version. Consider adding a note that Ruby >= 3.4 is now required.

### Notes
- The only change in the provider between 0.1.0 and 0.2.0 is the version bump and the updated `openfeature-sdk` dependency constraint. No provider logic changed.
- `openfeature-sdk` 0.6.x introduced provider eventing with async initialization. The `set_provider_and_wait` method preserves the synchronous behavior the hello app relies on.
- The `EvaluationContext` API is unchanged between 0.4.x and 0.6.x — the existing `key:`, `kind:`, `name:` keyword args still work as before.

Link to Devin session: https://app.devin.ai/sessions/08f3cd3234064ec88a183840412143ee
Requested by: @kinyoklion